### PR TITLE
Makefile: Fix CFLAGS overriding.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION = 0.0.0
 
-CFLAGS := -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wall -Wextra -O3 -g -MMD $(CFLAGS)
+override CFLAGS := -std=gnu99 -D_FILE_OFFSET_BITS=64 -Wall -Wextra -O3 -g -MMD $(CFLAGS)
 
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
@@ -11,7 +11,7 @@ PKG_CONFIG_PATH ?= $(LIBDIR)/pkgconfig
 -include .config
 
 ifdef CONFIG_NDEBUG
-    CFLAGS += -DNDEBUG
+    override CFLAGS += -DNDEBUG
 endif
 
 ifdef CONFIG_WINDOWS


### PR DESCRIPTION
Hi,

This is never ending story... This patch fixes the case when CFLAGS defined in Makefile is overridden with one specified by user. 

With patch:

```
$ make CC=gcc LDFLAGS=-pg CFLAGS=-pg CONFIG_NDEBUG=1
-std=gnu99 -D_FILE_OFFSET_BITS=64 -Wall -Wextra -O3 -g -MMD -pg -DNDEBUG
```

Without patch:

```
$ make CC=gcc LDFLAGS=-pg CFLAGS=-pg CONFIG_NDEBUG=1
-pg
```

I hope this is last time we are fixing this thing :)
