### PR TITLE
Add link to lib with the lib*.so.[0-9] pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ install-lib: $(OUT_LIB) dcadec.pc
 	install -m 644 dcadec.pc $(DESTDIR)$(LIBDIR)/pkgconfig
 ifdef SONAME
 	ln -sf libdcadec$(DLLSUF)$(SONAMESUF) $(DESTDIR)$(LIBDIR)/libdcadec$(DLLSUF)
+	ln -sf libdcadec$(DLLSUF)$(SONAMESUF) $(DESTDIR)$(LIBDIR)/libdcadec$(DLLSUF)$(SONAMESUF_MAJOR)
 endif
 
 install-dec: $(OUT_DEC)


### PR DESCRIPTION
On FreeBSD we need a lib name with this pattern.

see: https://www.freebsd.org/cgi/man.cgi?query=ldconfig&sektion=8

```
Filenames must conform to the lib*.so.[0-9] pattern in order to be added to the hints file.
```
